### PR TITLE
Update freds_bad_day.py

### DIFF
--- a/Part 8/freds_bad_day.py
+++ b/Part 8/freds_bad_day.py
@@ -110,7 +110,7 @@ while True:
 
 	elif gameStarted is True and gameOver is True:
 		surface.blit(endScreen, (0, 0))
-		timeLasted = (gameFinishedTime - gameStartedTime) / 1000
+		timeLasted = int((gameFinishedTime - gameStartedTime) / 1000)
 	
 		if timeLasted < 10:
 			timeLasted = "0" + str(timeLasted)


### PR DESCRIPTION
recommend turning timeLasted into integer, so that it fits on gameOver screen (without 2 place decimal)